### PR TITLE
Fix for agent SSL mode

### DIFF
--- a/modules/gbp/manifests/old/opflex_agent.pp
+++ b/modules/gbp/manifests/old/opflex_agent.pp
@@ -2,7 +2,7 @@ class gbp::opflex_agent(
   $opflex_log_level = 'debug2',
   $opflex_peer_ip = '10.0.0.30',
   $opflex_peer_port = '8009',
-  $opflex_ssl_mode = 'enabled',
+  $opflex_ssl_mode = 'encrypted',
   $opflex_endpoint_dir = '/var/lib/opflex-agent-ovs/endpoints',
   $opflex_ovs_bridge_name = 'br-int',
   $opflex_encap_iface = 'br-int_vxlan0',

--- a/modules/gbp/manifests/opflex_agent.pp
+++ b/modules/gbp/manifests/opflex_agent.pp
@@ -2,7 +2,7 @@ class gbp::opflex_agent(
   $opflex_log_level = 'debug2',
   $opflex_peer_ip = '10.0.0.30',
   $opflex_peer_port = '8009',
-  $opflex_ssl_mode = 'enabled',
+  $opflex_ssl_mode = 'encrypted',
   $opflex_endpoint_dir = '/var/lib/opflex-agent-ovs/endpoints',
   $opflex_ovs_bridge_name = 'br-int',
   $opflex_encap_iface = 'br-int_vxlan0',


### PR DESCRIPTION
The agent's SSL mode was incorrectly being set to "enabled".
This isn't a valid mode. This patch fixes it to use the correct
parameter, "encrypted".